### PR TITLE
ensure latest revision is returned for proxies and shared flows

### DIFF
--- a/apigee/resource_shared_flow.go
+++ b/apigee/resource_shared_flow.go
@@ -121,9 +121,25 @@ func resourceSharedFlowRead(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	d.Set("name", d.Id())
-	//Retrieve the latest revision available as THE revision, assumes array is sorted
-	lastRevision := retVal.Revisions[len(retVal.Revisions)-1]
-	revision, _ := strconv.Atoi(lastRevision)
+	//Empirically the revisions array is sorted *alphabetically* when we get
+	//it which means that, for example, an API with 10 revisions comes back
+	//with a revision list of 1, 10, 2, 3, 4, 5, 6, 7, 8, 9. As such we need
+	//to iteratate over the entire array to determine the latest revision.
+	//Any errors which arise parsing revision numbers are returned as a
+	//diagnostic.
+	revision := 0
+	for _, revisionStr := range retVal.Revisions {
+		rn, err := strconv.Atoi(revisionStr)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if rn > revision {
+			revision = rn
+		}
+	}
+	if revision == 0 {
+		return diag.Errorf("shared flow has no latest revision")
+	}
 	d.Set("revision", revision)
 	return diags
 }


### PR DESCRIPTION
Empirically, the Apigee proxy and shared flow APIs return the list of
revisions sorted alphabetically rather than numerically. This means, for
example, that a proxy with 10 revisions will have the revision list
returned as 1, 10, 2, 3, 4, 5, 6, 7, 8, 9. This in turn means that once
a proxy or shared flow reaches revision 9, that will continue to be its
"latest" revision until revision 99 or 999, etc.

Fix this by iterating over the list of revisions returned by the API and
selecting the maximum when parsed as an integer.

Closes #33