### PR TITLE
support "service_account" in proxy deployments

### DIFF
--- a/apigee/client/proxy_deployment.go
+++ b/apigee/client/proxy_deployment.go
@@ -11,6 +11,7 @@ type ProxyEnvironmentDeployment struct {
 	ProxyName       string                               `json:"name"`
 	EnvironmentName string                               `json:"environment"`
 	Revisions       []ProxyEnvironmentRevisionDeployment `json:"revision"`
+	ServiceAccount  string                               `json:"serviceAccount"`
 }
 type ProxyEnvironmentRevisionDeployment struct {
 	Name string `json:"name"`
@@ -22,6 +23,7 @@ type GoogleProxyEnvironmentDeploymentDeployments struct {
 	ProxyName       string `json:"apiProxy"`
 	EnvironmentName string `json:"environment"`
 	Revision        string `json:"revision"`
+	ServiceAccount  string `json:"serviceAccount"`
 }
 
 func (c *ProxyEnvironmentDeployment) ProxyDeploymentEncodeId() string {

--- a/docs/resources/proxy_deployment.md
+++ b/docs/resources/proxy_deployment.md
@@ -21,6 +21,7 @@ resource "apigee_proxy_deployment" "example" {
 * `environment_name` - **(Required, ForceNew, String)** The environment to deploy the proxy to.
 * `revision` - **(Required, Integer)** The revision of the proxy to deploy.  On create, it will assume the proxy has not been deployed in the given environment yet.  On update, it will override any current deployment to the given environment.
 * `delay` - **(Optional, Integer)** Time interval, in seconds, to wait before undeploying the currently deployed revision.  Default: 0. Ignored for calculating diffs.
+* `service_account` - **(Optional, String)** For Google instances, specify the service account associated with the deployment. See the [Google documentation](https://cloud.google.com/apigee/docs/api-platform/security/google-auth/overview#about-service-account-permissions) for permissions required by the deploying user.
 ## Attribute Reference
 * `id` - Same as `environment_name`:`proxy_name`
 ## Import


### PR DESCRIPTION
Apigee X [allows service account identities to be associated with proxy deployments](https://cloud.google.com/apigee/docs/api-platform/security/google-auth/overview). Expose a "service_account" field on `apigee_proxy_deployment` which allows this to be specified for Google instances.

Closes #35