### PR TITLE
shared_flow_deployment: allow specifying a service account

### DIFF
--- a/apigee/client/shared_flow_deployment.go
+++ b/apigee/client/shared_flow_deployment.go
@@ -11,6 +11,7 @@ type SharedFlowDeployment struct {
 	SharedFlowName  string                         `json:"name"`
 	EnvironmentName string                         `json:"environment"`
 	Revisions       []SharedFlowRevisionDeployment `json:"revision"`
+	ServiceAccount  string                         `json:"serviceAccount"`
 }
 type SharedFlowRevisionDeployment struct {
 	Name string `json:"name"`
@@ -24,6 +25,7 @@ type GoogleSharedFlowDeploymentDeployments struct {
 	SharedFlowName  string `json:"apiProxy"`
 	EnvironmentName string `json:"environment"`
 	Revision        string `json:"revision"`
+	ServiceAccount  string `json:"serviceAccount"`
 }
 
 func (c *SharedFlowDeployment) SharedFlowDeploymentEncodeId() string {

--- a/apigee/resource_proxy_deployment.go
+++ b/apigee/resource_proxy_deployment.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 func resourceProxyDeployment() *schema.Resource {
@@ -124,7 +125,8 @@ func resourceProxyDeploymentRead(ctx context.Context, d *schema.ResourceData, m 
 	if c.IsGoogle() {
 		googleRetVal := retVal.(*client.GoogleProxyEnvironmentDeployment)
 		serviceAccount := googleRetVal.Deployments[len(googleRetVal.Deployments)-1].ServiceAccount
-		d.Set("service_account", serviceAccount)
+		//When reading the service account, it is prefixed by "projects/-/serviceAccounts/"
+		d.Set("service_account", strings.TrimPrefix(serviceAccount, "projects/-/serviceAccounts/"))
 	} else {
 		d.Set("service_account", nil)
 	}

--- a/docs/resources/shared_flow_deployment.md
+++ b/docs/resources/shared_flow_deployment.md
@@ -21,6 +21,7 @@ resource "apigee_shared_flow_deployment" "example" {
 * `environment_name` - **(Required, ForceNew, String)** The environment to deploy the shared_flow to.
 * `revision` - **(Required, Integer)** The revision of the shared_flow to deploy.  On create, it will assume the shared_flow has not been deployed in the given environment yet.  On update, it will override any current deployment to the given environment.
 * `delay` - **(Optional, Integer)** Time interval, in seconds, to wait before undeploying the currently deployed revision.  Default: 0. Ignored for calculating diffs.
+* `service_account` - **(Optional, String)** For Google Cloud Apigee version, specify the service account associated with the deployment. See the [Google documentation](https://cloud.google.com/apigee/docs/api-platform/security/google-auth/overview#about-service-account-permissions) for permissions required by the deploying user.
 ## Attribute Reference
 * `id` - Same as `environment_name`:`shared_flow_name`
 ## Import


### PR DESCRIPTION
> Apologies, this should have been part of https://github.com/scastria/terraform-provider-apigee/pull/36. :(

Much as a proxy deployment can take a service account when deployed, shared flow can do the same. Use the same implementation as used with proxy_deployment for shared_flow_deployment.

This also fixes a round-trip bug for service accounts where one can (and should) pass a naked email-address formatted identifier in when creating the deployment but when reading the deployment back from the API, it is prefixed with `projects/-/serviceAccounts/`. Work around this by stripping the prefix (if present) when reading the resource.