### PR TITLE
pass service account to deployment creation if set

### DIFF
--- a/apigee/resource_proxy_deployment.go
+++ b/apigee/resource_proxy_deployment.go
@@ -63,6 +63,7 @@ func resourceProxyDelayDiff(k string, old string, n string, d *schema.ResourceDa
 func resourceProxyDeploymentCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := m.(*client.Client)
+	v := url.Values{}
 	newProxyDeployment := client.ProxyEnvironmentDeployment{
 		EnvironmentName: d.Get("environment_name").(string),
 		ProxyName:       d.Get("proxy_name").(string),
@@ -72,10 +73,11 @@ func resourceProxyDeploymentCreate(ctx context.Context, d *schema.ResourceData, 
 			return diag.Errorf("service_account cannot be set for non-Google Cloud Apigee versions")
 		}
 		newProxyDeployment.ServiceAccount = d.Get("service_account").(string)
+		v.Set("serviceAccount", newProxyDeployment.ServiceAccount)
 	}
 	revision := d.Get("revision").(int)
 	requestPath := fmt.Sprintf(client.ProxyEnvironmentDeploymentRevisionPath, c.Organization, newProxyDeployment.EnvironmentName, newProxyDeployment.ProxyName, revision)
-	_, err := c.HttpRequest(http.MethodPost, requestPath, nil, nil, &bytes.Buffer{})
+	_, err := c.HttpRequest(http.MethodPost, requestPath, v, nil, &bytes.Buffer{})
 	if err != nil {
 		d.SetId("")
 		return diag.FromErr(err)

--- a/apigee/resource_shared_flow_deployment.go
+++ b/apigee/resource_shared_flow_deployment.go
@@ -63,6 +63,7 @@ func resourceSharedFlowDelayDiff(k string, old string, n string, d *schema.Resou
 func resourceSharedFlowDeploymentCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := m.(*client.Client)
+	v := url.Values{}
 	newSharedFlowDeployment := client.SharedFlowDeployment{
 		EnvironmentName: d.Get("environment_name").(string),
 		SharedFlowName:  d.Get("shared_flow_name").(string),
@@ -72,10 +73,11 @@ func resourceSharedFlowDeploymentCreate(ctx context.Context, d *schema.ResourceD
 			return diag.Errorf("service_account cannot be set for non-Google Cloud Apigee versions")
 		}
 		newSharedFlowDeployment.ServiceAccount = d.Get("service_account").(string)
+		v.Set("serviceAccount", newSharedFlowDeployment.ServiceAccount)
 	}
 	revision := d.Get("revision").(int)
 	requestPath := fmt.Sprintf(client.SharedFlowDeploymentRevisionPath, c.Organization, newSharedFlowDeployment.EnvironmentName, newSharedFlowDeployment.SharedFlowName, revision)
-	_, err := c.HttpRequest(http.MethodPost, requestPath, nil, nil, &bytes.Buffer{})
+	_, err := c.HttpRequest(http.MethodPost, requestPath, v, nil, &bytes.Buffer{})
 	if err != nil {
 		d.SetId("")
 		return diag.FromErr(err)


### PR DESCRIPTION
When deploying a proxy or shared flow with a Google service account set, the "serviceAccount" query parameter [must be set when creating the deployment initially](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments.sharedflows.revisions.deployments/deploy). Failure to set the parameter causes the deployment to be created without a service account identity necessitating a second terraform apply to fix.

Fix this by providing the query parameter when creating a new deployment. The query string remains empty if no service account is being used.