### PR TITLE
Adding Support for Target Server's SSL Common Name Field

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       -
         name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,12 @@
 #
 name: release
 on:
-  push:
-    tags:
-      - 'v*'
+  # push:
+  #   tags:
+  #     - 'v*'
+  release:
+    types:
+      - published
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,9 @@
 #
 name: release
 on:
-  # push:
-  #   tags:
-  #     - 'v*'
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - 'v*'
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/apigee/client/ssl_info.go
+++ b/apigee/client/ssl_info.go
@@ -1,20 +1,27 @@
 package client
 
+type SSLCommonName struct {
+	Value         string `json:"value,omitempty"`
+	WildcardMatch bool   `json:"wildcardMatch,omitempty"`
+}
+
 type SSL struct {
-	Enabled                string   `json:"enabled"`
-	KeyStore               string   `json:"keyStore,omitempty"`
-	KeyAlias               string   `json:"keyAlias,omitempty"`
-	TrustStore             string   `json:"trustStore,omitempty"`
-	ClientAuthEnabled      string   `json:"clientAuthEnabled,omitempty"`
-	IgnoreValidationErrors bool     `json:"ignoreValidationErrors,omitempty"`
-	Protocols              []string `json:"protocols,omitempty"`
+	Enabled                string         `json:"enabled"`
+	KeyStore               string         `json:"keyStore,omitempty"`
+	KeyAlias               string         `json:"keyAlias,omitempty"`
+	TrustStore             string         `json:"trustStore,omitempty"`
+	CommonName             *SSLCommonName `json:"commonName,omitempty"`
+	ClientAuthEnabled      string         `json:"clientAuthEnabled,omitempty"`
+	IgnoreValidationErrors bool           `json:"ignoreValidationErrors,omitempty"`
+	Protocols              []string       `json:"protocols,omitempty"`
 }
 type GoogleSSL struct {
-	Enabled                bool     `json:"enabled"`
-	KeyStore               string   `json:"keyStore,omitempty"`
-	KeyAlias               string   `json:"keyAlias,omitempty"`
-	TrustStore             string   `json:"trustStore,omitempty"`
-	ClientAuthEnabled      bool     `json:"clientAuthEnabled,omitempty"`
-	IgnoreValidationErrors bool     `json:"ignoreValidationErrors,omitempty"`
-	Protocols              []string `json:"protocols,omitempty"`
+	Enabled                bool           `json:"enabled"`
+	KeyStore               string         `json:"keyStore,omitempty"`
+	KeyAlias               string         `json:"keyAlias,omitempty"`
+	TrustStore             string         `json:"trustStore,omitempty"`
+	CommonName             *SSLCommonName `json:"commonName,omitempty"`
+	ClientAuthEnabled      bool           `json:"clientAuthEnabled,omitempty"`
+	IgnoreValidationErrors bool           `json:"ignoreValidationErrors,omitempty"`
+	Protocols              []string       `json:"protocols,omitempty"`
 }

--- a/apigee/resource_target_server.go
+++ b/apigee/resource_target_server.go
@@ -64,24 +64,24 @@ func resourceTargetServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"ssl_common_name": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"value": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							DefaultFunc: schema.EnvDefaultFunc("COMMON_NAME", nil),
-						},
-						"wildcardMatch": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
+			// "ssl_common_name": {
+			// 	Type:     schema.TypeSet,
+			// 	Optional: true,
+			// 	MaxItems: 1,
+			// 	Elem: &schema.Resource{
+			// 		Schema: map[string]*schema.Schema{
+			// 			"value": {
+			// 				Type:        schema.TypeString,
+			// 				Optional:    true,
+			// 				DefaultFunc: schema.EnvDefaultFunc("COMMON_NAME", nil),
+			// 			},
+			// 			"wildcardMatch": {
+			// 				Type:     schema.TypeBool,
+			// 				Optional: true,
+			// 			},
+			// 		},
+			// 	},
+			// },
 			"ssl_client_auth_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -175,10 +175,10 @@ func fillTargetServer(c *client.TargetServer, d *schema.ResourceData) {
 		if ok {
 			c.SSLInfo.TrustStore = sslTrustStore.(string)
 		}
-		sslCommonName, ok := d.GetOk("ssl_common_name.0")
-		if ok {
-			c.SSLInfo.CommonName = sslCommonName.(*client.SSLCommonName)
-		}
+		// sslCommonName, ok := d.GetOk("ssl_common_name.0")
+		// if ok {
+		// 	c.SSLInfo.CommonName = sslCommonName.(*client.SSLCommonName)
+		// }
 		protocols, ok := d.GetOk("protocols")
 		if ok {
 			set := protocols.(*schema.Set)
@@ -213,10 +213,10 @@ func fillGoogleTargetServer(c *client.GoogleTargetServer, d *schema.ResourceData
 		if ok {
 			c.SSLInfo.TrustStore = sslTrustStore.(string)
 		}
-		sslCommonName, ok := d.GetOk("ssl_common_name.0")
-		if ok {
-			c.SSLInfo.CommonName = sslCommonName.(*client.SSLCommonName)
-		}
+		// sslCommonName, ok := d.GetOk("ssl_common_name.0")
+		// if ok {
+		// 	c.SSLInfo.CommonName = sslCommonName.(*client.SSLCommonName)
+		// }
 		protocols, ok := d.GetOk("protocols")
 		if ok {
 			set := protocols.(*schema.Set)
@@ -257,7 +257,7 @@ func resourceTargetServerRead(ctx context.Context, d *schema.ResourceData, m int
 	var host, keyStore, keyAlias, trustStore string
 	var port int
 	var isEnabled, hasSSL, sslEnabled, clientAuthEnabled, ignoreValidationErrors bool
-	var commonName *client.SSLCommonName
+	// var commonName *client.SSLCommonName
 	var protocols []string
 	if c.IsGoogle() {
 		ts := retVal.(*client.GoogleTargetServer)
@@ -269,7 +269,7 @@ func resourceTargetServerRead(ctx context.Context, d *schema.ResourceData, m int
 			keyStore = ts.SSLInfo.KeyStore
 			keyAlias = ts.SSLInfo.KeyAlias
 			trustStore = ts.SSLInfo.TrustStore
-			commonName = ts.SSLInfo.CommonName
+			// commonName = ts.SSLInfo.CommonName
 			sslEnabled = ts.SSLInfo.Enabled
 			clientAuthEnabled = ts.SSLInfo.ClientAuthEnabled
 			ignoreValidationErrors = ts.SSLInfo.IgnoreValidationErrors
@@ -285,7 +285,7 @@ func resourceTargetServerRead(ctx context.Context, d *schema.ResourceData, m int
 			keyStore = ts.SSLInfo.KeyStore
 			keyAlias = ts.SSLInfo.KeyAlias
 			trustStore = ts.SSLInfo.TrustStore
-			commonName = ts.SSLInfo.CommonName
+			// commonName = ts.SSLInfo.CommonName
 			sslEnabledBool, _ := strconv.ParseBool(ts.SSLInfo.Enabled)
 			sslEnabled = sslEnabledBool
 			clientAuthEnabledBool, _ := strconv.ParseBool(ts.SSLInfo.ClientAuthEnabled)
@@ -304,7 +304,7 @@ func resourceTargetServerRead(ctx context.Context, d *schema.ResourceData, m int
 		d.Set("ssl_keystore", keyStore)
 		d.Set("ssl_keyalias", keyAlias)
 		d.Set("ssl_truststore", trustStore)
-		d.Set("ssl_common_name.0", commonName)
+		// d.Set("ssl_common_name.0", commonName)
 		d.Set("ssl_client_auth_enabled", clientAuthEnabled)
 		d.Set("ssl_ignore_validation_errors", ignoreValidationErrors)
 		d.Set("protocols", protocols)

--- a/apigee/resource_target_server.go
+++ b/apigee/resource_target_server.go
@@ -185,6 +185,8 @@ func fillTargetServer(c *client.TargetServer, d *schema.ResourceData) {
 			value, ok := d.GetOk("ssl_common_name.0.value")
 			if ok {
 				c.SSLInfo.CommonName.Value = value.(string)
+			} else {
+				c.SSLInfo.CommonName.Value = c.Host
 			}
 
 			wildcard_match, ok := d.GetOk("ssl_common_name.0.wildcard_match")
@@ -233,6 +235,8 @@ func fillGoogleTargetServer(c *client.GoogleTargetServer, d *schema.ResourceData
 			value, ok := d.GetOk("ssl_common_name.0.value")
 			if ok {
 				c.SSLInfo.CommonName.Value = value.(string)
+			} else {
+				c.SSLInfo.CommonName.Value = c.Host
 			}
 
 			wildcard_match, ok := d.GetOk("ssl_common_name.0.wildcard_match")


### PR DESCRIPTION
Currently the interface that is supported for `SSL` in the `TargetServer` resource does not support the entirety of the Google Cloud implementation ([see here](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments.targetservers#tlsinfo))

This adds the support for providing, or defaulting, the `TargetServer.TlsInfo.CommonName` field.