### PR TITLE
Adding operation type support - to include "remoteservice" 

### DIFF
--- a/apigee/resource_product.go
+++ b/apigee/resource_product.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"regexp"
+	"strconv"
 
 	"github.com/go-http-utils/headers"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/apigee/resource_product.go
+++ b/apigee/resource_product.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"regexp"
 
 	"github.com/go-http-utils/headers"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -96,18 +97,9 @@ func resourceProduct() *schema.Resource {
 				},
 			},
 			"operation_config_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: func(val interface{}, key string) ([]string, []error) {
-					value := val.(string)
-					if value != "proxy" && value != "remoteservice" {
-						return []string{}, []error{fmt.Errorf("Invalid value for %s, must be either 'proxy' or 'remoteservice'", key)}
-					}
-					return nil, nil
-				},
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(proxy|remoteservice)$`), "Invalid value, operation_config_type must be either 'proxy' or 'remoteservice'"),
 			},
 			"operation": {
 				Type:     schema.TypeList,

--- a/docs/resources/product.md
+++ b/docs/resources/product.md
@@ -58,7 +58,7 @@ resource "apigee_product" "example" {
   * `quota_interval` - **(Optional, Integer)** Time interval over which the number of request messages is calculated.
   * `quota_time_unit` - **(Optional, String)** Time unit defined for the `quota_interval`.  Allowed values: `minute`, `hour`, `day`, `month`.
   * `attributes` - **(Optional, Map of String to String)** Keys and values to be stored as custom attributes of the operation.
-* `operation_config_type` - **(Optional, String)** The Operation config type can either be `proxy`, `remoteservice`.
+* `operation_config_type` - **(Optional, String)** The Operation config type for the product, can either be `proxy` or `remoteservice`.
 
 ## Attribute Reference
 * `id` - Same as `name`

--- a/docs/resources/product.md
+++ b/docs/resources/product.md
@@ -58,6 +58,7 @@ resource "apigee_product" "example" {
   * `quota_interval` - **(Optional, Integer)** Time interval over which the number of request messages is calculated.
   * `quota_time_unit` - **(Optional, String)** Time unit defined for the `quota_interval`.  Allowed values: `minute`, `hour`, `day`, `month`.
   * `attributes` - **(Optional, Map of String to String)** Keys and values to be stored as custom attributes of the operation.
+* `operation_config_type` - **(Optional, String)** The Operation config type can either be `proxy`, `remoteservice`.
 
 ## Attribute Reference
 * `id` - Same as `name`


### PR DESCRIPTION
```terraform
resource "apigee_product" "apigee_product" {
  name               = "httpbin"
  display_name  = "httpbin"
  auto_approval_type = true
  description        = "A httpbin product"
  environments = [
    "test"
  ]
  attributes = {
    access = "public"
  }
  operation {
    api_source = "httpbin.default.svc.cluster.local"
    path       = "/"
    methods    = ["GET", "PATCH", "POST", "PUT", "DELETE", "HEAD", "CONNECT", "OPTIONS", "TRACE"]
  }
  operation_config_type = "remoteservice" # New setting -- completely optional, defaults to proxy
}
```

- OperationGroup settings allow for remote service and proxy as setting [documentation](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.apiproducts#OperationGroup)

This is very useful for working with the remote service envoy plugin with Apigee

- [remote-service-envoy](https://github.com/apigee/apigee-remote-service-envoy)

## Testing

I've tested it with setting the operation_config_type variable as follows

- keeping empty or not giving any value --> defaults to operationConfigType as proxy
- as "remoteservice" --> correctly sets the httpbin product operationConfigType as remoteservice
- as "random" --> throws an error "Invalid value for operation_config_type, must be either 'proxy' or 'remoteservice'"

@ev-the-dev -- Would love a review from you, thanks!