### PR TITLE
modifying apigee proxy deployment condition to work with google custo…

### DIFF
--- a/apigee/client/client.go
+++ b/apigee/client/client.go
@@ -123,11 +123,11 @@ func NewClient(username string, password string, accessToken string, useSSL bool
 }
 
 func (c *Client) IsPublic() bool {
-	return (c.server == PublicApigeeServer) || (c.server == GoogleApigeeServer)
+	return (c.server == PublicApigeeServer) || strings.Contains(c.server, GoogleApigeeServer)
 }
 
 func (c *Client) IsGoogle() bool {
-	return c.server == GoogleApigeeServer
+    return strings.Contains(c.server, GoogleApigeeServer)
 }
 
 func (c *Client) HttpRequest(method string, path string, query url.Values, headerMap http.Header, body *bytes.Buffer) (closer io.ReadCloser, err error) {


### PR DESCRIPTION
I am working on a critical project and i created Apigee proxy successfully; however, the proxy deployment encounters an issue with error:

"service_account cannot be set for non-Google Cloud Apigee."

I believe this error occurs because we are using a custom regional endpoint. After reviewing the Apigee provider's source code,

I identified the root cause in how the server parameter is validated.

The current code compares the server parameter, which in our case is set to the custom endpoint "sa-apigee.googleapis.com", with a defined variable GoogleApigeeServer which is "apigee.googleapis.com"

Since the custom endpoint does not match the variable, this mistakenly identifies

our setup as "non-Google Cloud Apigee," resulting in the error during the apply phase.

so I updated the source code to make sure that even google custom end-points are considered as Google Cloud Apigee.